### PR TITLE
Add build badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # SwiftCommons
-A project focused on simple, small, and reusable Swift components.
+
+[![Build Status](https://github.com/mobileinf/SwiftCommons/actions/workflows/main.yml/badge.svg)](https://github.com/mobileinf/SwiftCommons/actions/workflows/main.yml)
+
+A project focused on simple, small, and reusable Swift components. It was created to support command line tools in [Mobile Infra](https://github.com/mobileinf).
+
+## License
+
+Curie is released under version 2.0 of the [Apache License](LICENSE.txt).


### PR DESCRIPTION
Test Plan:
- Ensure all CI checks pass
- Verify the badge is rendered correctly