### PR TITLE
Fix mise warning

### DIFF
--- a/.mise/tasks/autocorrect
+++ b/.mise/tasks/autocorrect
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Clean build directory"
+#MISE description="Clean build directory"
 set -euo pipefail
 
 source "$MISE_PROJECT_ROOT/.mise/helpers/common"

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Build the project"
+#MISE description="Build the project"
 set -euo pipefail
 
 source "$MISE_PROJECT_ROOT/.mise/helpers/common"

--- a/.mise/tasks/clean
+++ b/.mise/tasks/clean
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Clean build directory"
+#MISE description="Clean build directory"
 set -euo pipefail
 
 source "$MISE_PROJECT_ROOT/.mise/helpers/common"

--- a/.mise/tasks/env
+++ b/.mise/tasks/env
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Show environment"
+#MISE description="Show environment"
 set -euo pipefail
 
 source "$MISE_PROJECT_ROOT/.mise/helpers/common"

--- a/.mise/tasks/format
+++ b/.mise/tasks/format
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Format the project"
+#MISE description="Format the project"
 set -euo pipefail
 
 swiftformat $MISE_PROJECT_ROOT

--- a/.mise/tasks/lint
+++ b/.mise/tasks/lint
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Lint the project"
+#MISE description="Lint the project"
 set -euo pipefail
 
 source "$MISE_PROJECT_ROOT/.mise/helpers/common"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Test the project"
+#MISE description="Test the project"
 set -euo pipefail
 
 source "$MISE_PROJECT_ROOT/.mise/helpers/common"


### PR DESCRIPTION
Addressed the warning

```
WARN  deprecated [file_task_headers_old_syntax]: The `# mise ...` syntax for task headers is deprecated and will be removed in mise 2026.3.0. Use the new `#MISE ...` syntax instead.
```

Test Plan:
- Ensure all CI checks pass
- Verify the warning does not show up in the logs