### PR TITLE
Add GitHub token for GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   DEVELOPER_DIR: "/Applications/Xcode_26.0.1.app/Contents/Developer"
+  GITHUB_API_TOKEN: ${{ github.token }}
 
 permissions:
   contents: read


### PR DESCRIPTION
It should prevent mise from running into rate limit.

Test Plan:
- Ensure all CI checks pass